### PR TITLE
Feature: Add AMQ 7 on RHEL 8 platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This repository provides a set of generic roles and reusable playbooks for deplo
 6. [JBoss Datagrid](https://github.com/redhat-cop/jboss_datagrid)
 
 ## Ansible Install and Version
+
 We are currently working against ansible 2.5 `pip` is the preferred installed method for now: `pip install ansible==2.5`
 
 ## Transfer Methods
@@ -27,25 +28,27 @@ We are currently working against ansible 2.5 `pip` is the preferred installed me
 These playbooks and their required roles support a few different mechanisms for transferring the product zip files to the target host. You can set the variable `transfer_method` to select the method, which can be set at multiple levels. The default is set in [group vars](group_vars/all/all.yml).
 
 ### csp-to-host
+
 This method uses the [custom redhat_csp_download module](https://github.com/sabre1041/redhat-csp-download) to download the product binaries from the [Red Hat Customer Portal](https://access.redhat.com/downloads/). This requires network access from the target host to the Red Hat Customer Portal, but has the advantage of being fully automated. Each of the roles have sensible defaults already set.
 
 The following variables are required:
+
 - `rhn_username`
 - `rhn_password`
 
 ### copy-from-controller
+
 This method requires you to download the product binaries from the [Red Hat Customer Portal](https://access.redhat.com/downloads/) and then add them to the files directory. This has the benefit of supporting installs when the target host does have public internet connectivity, but requires a manual step before the playbook can be run. Each of the roles have sensible defaults already set, and the .gitignore will ignore .zip files.
 
 The easiest way to provide the files to your role is to symlink them to the role_name/files directory. If you files are not named the same as the files on the customer portal, you can override the file name using the `*_artifact_name` variables.
 
-## CI and Testing 
+## CI and Testing
 
 All of the roles are using some variation of [Chris Meyer's](https://github.com/chrismeyersfsu) incredible [Travis CI, Docker and Ansible role testing method](https://www.ansible.com/blog/testing-ansible-roles-with-docker).
 
 ## Red Hat Subscriptions
 
 These playbooks require binaries from the [Red Hat Customer Portal](https://access.redhat.com/downloads/), so you'll need a valid subscription. Developers can get a $0 subscription through the [Red Hat Developer Program](http://developers.redhat.com/products/eap/download/).
-
 
 ## Best Practices
 

--- a/amq7.2-rhel7.yml
+++ b/amq7.2-rhel7.yml
@@ -1,12 +1,20 @@
 ---
 
 - hosts: jboss_amq_rhel_hosts
-  become_user: "{{ ansible_rhel_user }}"
-  become: true
   gather_facts: true
+  become: true
+  become_user: "{{ ansible_rhel_user }}"
+  become_method: sudo
 
   # Set capabilities to install
   vars:
+    # redhat-cop.jboss_common
+    rhsm_subscribe_host: False
+    rhsm_disable_existing_repositories: False
+    rhsm_enable_required_repositories: False
+    # redhat-cop.jboss_amq
+    amq_version: 7.2.4
+    jboss_amq_artifact_source: https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=66191
     role_install_broker: true
     role_install_interconnect: false
 

--- a/amq7.6-rhel8.yml
+++ b/amq7.6-rhel8.yml
@@ -5,7 +5,7 @@
   become: true
   become_user: "{{ ansible_rhel_user }}"
   become_method: sudo
-
+  
   # Set capabilities to install
   vars:
     # redhat-cop.jboss_common
@@ -13,8 +13,8 @@
     rhsm_disable_existing_repositories: False
     rhsm_enable_required_repositories: False
     # redhat-cop.jboss_amq
-    amq_version: 7.1.0
-    jboss_amq_artifact_source: https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=56531
+    amq_version: 7.6.0
+    jboss_amq_artifact_source: https://access.redhat.com/jbossnetwork/restricted/softwareDownload.html?softwareId=79671
     role_install_broker: true
     role_install_interconnect: false
 
@@ -29,4 +29,17 @@
 
   roles:
     - role: redhat-cop.jboss_common
-    - role: redhat-cop.jboss_amq
+    # Two AMQ Brokers in Master/Slave topology with a shared storage
+    - {
+        role: redhat-cop.jboss_amq,
+        amq_broker_name: master,
+        amq_broker_shared_storage: True
+      }
+    - {
+        role: redhat-cop.jboss_amq,
+        amq_broker_name: slave,
+        amq_broker_shared_storage: True,
+        amq_broker_replicate: True,
+        amq_broker_ports_offset_enabled: True,
+        amq_broker_ports_offset: 100
+      }

--- a/group_vars/all/all.yml
+++ b/group_vars/all/all.yml
@@ -4,9 +4,5 @@ ansible_centos_user: centos
 
 ansible_rhel_user: cloud-user
 
-# Java 8 recommended
-# Full JDK (not just JRE) recommended. See https://access.redhat.com/solutions/18259
-eap_java_pkg_name: java-1.8.0-openjdk-devel
-
 # Override the default method. See https://github.com/rhtconsulting/jboss_eap/blob/master/README.md
 transfer_method: csp-to-host  #csp-to-host | copy-from-controller | file-server-to-host


### PR DESCRIPTION
Added some sample playbooks to deploy Red Hat AMQ 7.X on RHEL 7 or RHEL 8.

These playbooks include some topologies such as:

- Master/Slave on the same host
- Shared Storage
- Using port offsets to deploy more instances in the same hosts
